### PR TITLE
Added factorypath to git Ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 .idea
 *.iml
 .DS_Store
+.factorypath


### PR DESCRIPTION
I am not sure if any of you guys had this issue but my Eclipse Auto Complete plugin for Atom generates the Factorypath file so the auto complete plugin can function properly. So just added it to git ignore so it does not get pushed as a change to git.

Here's a link talking about it if you guys want to take a look:
[https://stackoverflow.com/questions/42949198/automatically-generate-factorypath-on-project-import-when-using-maven-project-i](url)